### PR TITLE
Indicate that python 3.6, 3.7 is supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ ptpython
 |Build Status|
 
 Ptpython is an advanced Python REPL. It should work on all
-Python versions from 2.6 up to 3.5 and work cross platform (Linux,
+Python versions from 2.6 up to 3.7 and work cross platform (Linux,
 BSD, OS X and Windows).
 
 


### PR DESCRIPTION
Indicate in the readme that 3.6 and 3.7 are also supported (otherwise a casual glance suggests the project is not maintained).